### PR TITLE
Streamline instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,12 +46,7 @@ machine, the following instructions will guide you.
 * <strong><code>apt list | grep python3.9</code></strong>
 * Install it:
 * <strong><code>sudo apt install python3.9</code></strong>
-* Let’s try just adding it to <code>$PATH</code> without messing with <code>update-alternatives</code>
-* If you run <strong><code>which python3.9</code></strong>, you should see <code>/usr/bin/python3.9</code>
-* Edit it into the $PATH: <strong><code>code ~/.bashrc </code></strong>and add this at the end of the file:
-* <strong><code>export PATH="$PATH/usr/bin/python3.9"</code></strong>
-* Either <strong><code>source ~/.bashrc</code></strong> or start a new bash shell
-* <strong><code>echo $PATH</code></strong> to verify it’s at the end.
+* If you run <strong><code>which python3.9</code></strong>, you should see <code>/usr/bin/python3.9</code> which means its already on the PATH.
 * Now when you run Pants you may get a new error: \
 <code>ModuleNotFoundError: No module named 'distutils.util'</code>
 * Fix with: <strong><code>sudo apt install python3.9-distutils</code></strong>


### PR DESCRIPTION
The deadsnakes ppa for python3.9 installs python3.9 in `/usr/bin` which is part of the standard $PATH:
```
$ dpkg -L python3.9-minimal
/.
/usr
/usr/bin
/usr/bin/python3.9
/usr/share
/usr/share/binfmts
/usr/share/binfmts/python3.9
/usr/share/doc
/usr/share/doc/python3.9-minimal
/usr/share/doc/python3.9-minimal/README.Debian.gz
/usr/share/doc/python3.9-minimal/changelog.Debian.gz
/usr/share/doc/python3.9-minimal/copyright
/usr/share/lintian
/usr/share/lintian/overrides
/usr/share/lintian/overrides/python3.9-minimal
/usr/share/man
/usr/share/man/man1
/usr/share/man/man1/python3.9.1.gz
```

It should be the case that the steps removed in this PR were never needed.